### PR TITLE
PLATFORM-398: FPM pool: make listen.owner & listen.group configurable

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -1,17 +1,34 @@
-define php5::fpm::pool($prefix = '', $listen = '127.0.0.1', $port = '9000',
-  $user = 'www-data', $group = 'www-data', $mode = '0666', $pm = 'dynamic',
-  $pm_max_children = 50, $pm_start_servers = 20, $pm_min_spare = 5, $pm_max_spare = 35,
-  $pm_max_requests = 0, $env = [], $php_values = [], $php_admin_values = [], $access_log_file = '',
-  $access_format = '', $misc_options = [], $ensure = 'present', $status_path = '/fpm-status',
-  $ping_path = '/fpm-ping') {
+define php5::fpm::pool(
+  $prefix           = '',
+  $listen           = '127.0.0.1',
+  $port             = '9000',
+  $user             = 'www-data',
+  $group            = 'www-data',
+  $mode             = '0666',
+  $pm               = 'dynamic',
+  $pm_max_children  = 50,
+  $pm_start_servers = 20,
+  $pm_min_spare     = 5,
+  $pm_max_spare     = 35,
+  $pm_max_requests  = 0,
+  $env              = [],
+  $php_values       = [],
+  $php_admin_values = [],
+  $access_log_file  = '',
+  $access_format    = '',
+  $misc_options     = [],
+  $ensure           = 'present',
+  $status_path      = '/fpm-status',
+  $ping_path        = '/fpm-ping'
+) {
 
-    file { "/etc/php5/fpm/pool.d/${name}.conf":
-      content   => template('php5/fpm-pool.conf.erb'),
-      owner     => root,
-      group     => root,
-      mode      => 0644,
-      require   => File['/etc/php5/fpm/pool.d/'],
-      notify    => Exec['reload-php5-fpm'],
-      ensure    => $ensure,
-    }
+  file { "/etc/php5/fpm/pool.d/${name}.conf":
+    content   => template('php5/fpm-pool.conf.erb'),
+    owner     => root,
+    group     => root,
+    mode      => 0644,
+    require   => File['/etc/php5/fpm/pool.d/'],
+    notify    => Exec['reload-php5-fpm'],
+    ensure    => $ensure,
+  }
 }

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -1,6 +1,8 @@
 define php5::fpm::pool(
   $prefix           = '',
   $listen           = '127.0.0.1',
+  $listen_owner     = '',
+  $listen_group     = '',
   $port             = '9000',
   $user             = 'www-data',
   $group            = 'www-data',

--- a/templates/fpm-pool.conf.erb
+++ b/templates/fpm-pool.conf.erb
@@ -3,6 +3,12 @@
 prefix = <%= @prefix %>
 <% end -%>
 listen = <%= @listen %><% if @port != "NOTSET" %>:<%= @port %><% end %>
+<% if @listen_owner != '' -%>
+listen.owner = <%= @listen_owner %>
+<% end -%>
+<% if @listen_group != '' -%>
+listen.group = <%= @listen_group %>
+<% end -%>
 user = <%= @user %>
 <% if @group -%>
 group = <%= @group %>


### PR DESCRIPTION
FPM pool: make `listen.owner` & `listen.group` config variables configurable. This is useful in case when `nginx` is not running under `root`.
