### PR TITLE
SRE_83: Fixing permission for Zend Opcache logging

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -43,10 +43,9 @@ class php5::fpm(
 
   file { "$log_directory":
     ensure  => directory,
-    recurse => true,
     owner   => root,
     group   => root,
-    mode    => '0755',
+    mode    => '1777',
     require => Package['php5-fpm'],
   }
 

--- a/templates/fpm-logrotate.erb
+++ b/templates/fpm-logrotate.erb
@@ -5,7 +5,7 @@
     compress
     compressoptions -4
     notifempty
-    create 640 root adm
+    create
     sharedscripts
     postrotate
     kill -USR1 `cat /var/run/php5-fpm.pid`


### PR DESCRIPTION
1. Fix Logrotate so it doesn't change permission of the files it rotates
2. `recurse` on File resource does not make sense without a `source` and it results in the permission being changed on files.

``````
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for store-app1-s.dal7sl.bigcommerce.net
Info: Applying configuration version '8a3baf6 - Wed Sep 14 13:34:48 2016 -0700'
Notice: /Stage[main]/Php5::Fpm/File[/etc/logrotate.d/php]/content: 
--- /etc/logrotate.d/php    2015-02-09 15:29:33.000000000 -0600
+++ /tmp/puppet-file20160914-14688-1pbbubi  2016-09-14 15:39:51.611470549 -0500
@@ -5,7 +5,7 @@
     compress
     compressoptions -4
     notifempty
-    create 640 root adm
+    create
     sharedscripts
     postrotate
     kill -USR1 `cat /var/run/php5-fpm.pid`

Info: Computing checksum on file /etc/logrotate.d/php
Info: /Stage[main]/Php5::Fpm/File[/etc/logrotate.d/php]: Filebucketed /etc/logrotate.d/php to puppet with sum 7dffbf5885611e88968a36fe53f655f2
Notice: /Stage[main]/Php5::Fpm/File[/etc/logrotate.d/php]/content: content changed '{md5}7dffbf5885611e88968a36fe53f655f2' to '{md5}68b7d5d3cbea9393d7c5aedd39c812a0'
Notice: /Stage[main]/Php5::Fpm/File[/var/log/php/]/mode: mode changed '0755' to '1777'
Notice: Finished catalog run in 40.25 seconds```
``````
