### PR TITLE
Change log directory permissions and log rotate create

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -45,7 +45,7 @@ class php5::fpm(
     ensure  => directory,
     owner   => root,
     group   => root,
-    mode    => '1777',
+    mode    => '1775',
     require => Package['php5-fpm'],
   }
 

--- a/templates/fpm-logrotate.erb
+++ b/templates/fpm-logrotate.erb
@@ -5,7 +5,7 @@
     compress
     compressoptions -4
     notifempty
-    create
+    create 664 root www-data
     sharedscripts
     postrotate
     kill -USR1 `cat /var/run/php5-fpm.pid`


### PR DESCRIPTION
This changes the log directory permissions to 1775 so they arent world writable.

Log rotate is now using `create 664 root www-data`

This will allow logrotate to work again

I have tested this change and can confirm it works still