### PR TITLE
change to use just create and copy permission of previous file

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -44,7 +44,7 @@ class php5::fpm(
   file { "$log_directory":
     ensure  => directory,
     owner   => root,
-    group   => root,
+    group   => www-data,
     mode    => '1775',
     require => Package['php5-fpm'],
   }

--- a/templates/fpm-logrotate.erb
+++ b/templates/fpm-logrotate.erb
@@ -5,7 +5,7 @@
     compress
     compressoptions -4
     notifempty
-    create 664 root www-data
+    create
     sharedscripts
     postrotate
     kill -USR1 `cat /var/run/php5-fpm.pid`


### PR DESCRIPTION
This changes permissions of the log directory to be www-data with sticky 1775
The log rotate config will just be create so they inherit the existing files permissions