### PR TITLE
change log rotate for php logs

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -44,7 +44,7 @@ class php5::fpm(
   file { "$log_directory":
     ensure  => directory,
     owner   => root,
-    group   => www-data,
+    group   => root,
     mode    => '1775',
     require => Package['php5-fpm'],
   }

--- a/templates/fpm-logrotate.erb
+++ b/templates/fpm-logrotate.erb
@@ -5,7 +5,7 @@
     compress
     compressoptions -4
     notifempty
-    create
+    create 664 root www-data
     sharedscripts
     postrotate
     kill -USR1 `cat /var/run/php5-fpm.pid`


### PR DESCRIPTION
change log rotate for php logs per SRE-417
This fixes it so that log rotate has the required permissions to run and rotate the php logs

Confirmed this works as expected and will rotate the logs
