### PR TITLE
Fix puppet compatibility issue with future parser

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -8,13 +8,15 @@ class php5::cli(
     before => Package['php5-common'],
   }
 
-  $config_changes += [
+  $cli_config_changes = [
     'set display_errors On',
   ]
 
+  $real_config_changes = concat($config_changes, $cli_config_changes);
+
   augeas { 'php.ini/cli/PHP':
     context => '/files/etc/php5/cli/php.ini/PHP/',
-    changes => $config_changes,
+    changes => $real_config_changes,
     require => Package['php5-cli'],
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,7 @@ define php5::config(
   $setting = '',
   $ensure  = 'present'
 ) {
-  if ($setting) {
+  if (!empty($setting)) {
     $use_setting = $setting
   }
   else {


### PR DESCRIPTION
## What does this do?
Fixes some compatibility issues with the php5 module.

## Why?
Puppet was broken on `legacy-app1-p` because of the future parser changes. This made it work properly and is currently running on the host. No other hosts are using the `php5::cli` class so it should have no impact elsewhere.

There's a few remaining puppet issues but I'll fix them separately